### PR TITLE
Fix font-face CSS property

### DIFF
--- a/source/stylesheets/utils/_fontface.scss
+++ b/source/stylesheets/utils/_fontface.scss
@@ -1,2 +1,2 @@
 //TODO: use local files
-@import 'https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900';
+@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);


### PR DESCRIPTION
`font-face` properties need an `url`. Some browsers don't have issues when you skip it, but unfortunately PhantomJS does (I'm using it for acceptance testing).
