### PR TITLE
Add !default to all variables

### DIFF
--- a/source/stylesheets/utils/_variables.scss
+++ b/source/stylesheets/utils/_variables.scss
@@ -1,0 +1,22 @@
+// Decidim Variables
+
+$primary: map-get($foundation-palette, primary) !default;
+$secondary: map-get($foundation-palette, secondary) !default;
+$success: map-get($foundation-palette, success) !default;
+$warning: map-get($foundation-palette, warning) !default;
+$alert: map-get($foundation-palette, alert) !default;
+
+$light-gray-dark: darken($light-gray, 2.5) !default;
+
+$proposals: #238FF7 !default;
+$actions: #57D685 !default;
+$debates: #FA6C96 !default;
+$meetings: #FABC6C !default;
+
+$twitter: #55acee !default;
+$facebook: #3b5998 !default;
+$google: #dd4b39 !default;
+
+$muted: lighten($body-font-color, 30) !default;
+
+$border: 1px solid $medium-gray !default;


### PR DESCRIPTION
#### :tophat: Scope of work
By adding `!default` to variable declarations, we're only setting them if no previous value is present. This allows external applications to override any of them.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: URLs
*None*

#### :ghost: GIF (optional)
![](https://media.giphy.com/media/113eti1n3sKfeM/giphy.gif)
