### PR TITLE
Logo image limited in height instead of width

### DIFF
--- a/source/stylesheets/modules/_navbar.scss
+++ b/source/stylesheets/modules/_navbar.scss
@@ -39,7 +39,7 @@ $navbar-active-shadow-medium: inset 0 4px 0 0 $primary;
   @include breakpoint(medium){
     top: 50%;
     margin-top: -19px;
-    img{ 
+    img{
       height: 38px !important;
     }
   }
@@ -62,9 +62,9 @@ $navbar-active-shadow-medium: inset 0 4px 0 0 $primary;
   }
   img{
     display: block;
-    max-width: 100px;
+    max-height: 33px;
     @include breakpoint(mediumlarge){
-      max-width: 140px;
+      max-height: 45px;
     }
   }
 }
@@ -251,7 +251,7 @@ $navbar-active-shadow-medium: inset 0 4px 0 0 $primary;
     background: $navbar-bg-hover;
     color: $navbar-color-hover;
   }
-  
+
   @include breakpoint(medium){
     padding: .75em 2em;
   }


### PR DESCRIPTION
#### :tophat: Scope of work
Logo image with a max-height instead of a max-width, allowing more
flexibility for other city halls logos.


#### :pushpin: Related Issues
- Fixes #70 