### PR TITLE
Fix deprecation warnings

### DIFF
--- a/source/stylesheets/modules/_typography.scss
+++ b/source/stylesheets/modules/_typography.scss
@@ -9,16 +9,16 @@ input{
 
 @mixin heading($heading) {
   line-height: 1.2;
-  font-size: map-get(map-get(map-get($header-styles, small), h1), 'font-size') / 16 + em;
+  font-size: map-get(map-get(map-get($header-styles, small), $heading), 'font-size') / 16 + em;
   @include breakpoint(medium){
-    font-size: map-get(map-get(map-get($header-styles, medium), h1), 'font-size') / 16 + em;
+    font-size: map-get(map-get(map-get($header-styles, medium), $heading), 'font-size') / 16 + em;
   }
 }
 
 .heading1{
-  line-height: 1.1;
   font-weight: 600;
   @include heading(h1);
+  line-height: 1.1;
 }
 
 .heading2{

--- a/source/stylesheets/modules/_typography.scss
+++ b/source/stylesheets/modules/_typography.scss
@@ -7,56 +7,41 @@ input{
   font-family: inherit;
 }
 
+@mixin heading($heading) {
+  line-height: 1.2;
+  font-size: map-get(map-get(map-get($header-styles, small), h1), 'font-size') / 16 + em;
+  @include breakpoint(medium){
+    font-size: map-get(map-get(map-get($header-styles, medium), h1), 'font-size') / 16 + em;
+  }
+}
+
 .heading1{
   line-height: 1.1;
   font-weight: 600;
-  font-size: map-get(map-get($header-sizes, small), h1) / 16 + em;
-  @include breakpoint(medium){
-    font-size: map-get(map-get($header-sizes, medium), h1) / 16 + em;
-  }
+  @include heading(h1);
 }
 
 .heading2{
-  line-height: 1.2;
-  //font-weight: 600;
-  font-size: map-get(map-get($header-sizes, small), h2) / 16 + em;
-  @include breakpoint(medium){
-    font-size: map-get(map-get($header-sizes, medium), h2) / 16 + em;
-  }
+  @include heading(h2);
 }
 
 .heading3{
-  line-height: 1.2;
-  font-size: map-get(map-get($header-sizes, small), h3) / 16 + em;
-  @include breakpoint(medium){
-    font-size: map-get(map-get($header-sizes, medium), h3) / 16 + em;
-  }
+  @include heading(h3);
 }
 
 .heading4{
-  line-height: 1.2;
-  font-size: map-get(map-get($header-sizes, small), h4) / 16 + em;
-  @include breakpoint(medium){
-    font-size: map-get(map-get($header-sizes, medium), h4) / 16 + em;
-  }
+  @include heading(h4);
 }
 
 .heading5{
-  line-height: 1.2;
-  font-size: map-get(map-get($header-sizes, small), h5) / 16 + em;
-  @include breakpoint(medium){
-    font-size: map-get(map-get($header-sizes, medium), h5) / 16 + em;
-  }
+  @include heading(h5);
 }
 
 .heading6{
   text-transform: uppercase;
   letter-spacing: .03em;
   font-weight: 600;
-  font-size: map-get(map-get($header-sizes, small), h6) / 16 + em;
-  @include breakpoint(medium){
-    font-size: map-get(map-get($header-sizes, medium), h6) / 16 + em;
-  }
+  @include heading(h6);
 }
 
 .heading-small{

--- a/source/stylesheets/utils/_settings.scss
+++ b/source/stylesheets/utils/_settings.scss
@@ -109,27 +109,29 @@ $header-font-family: $body-font-family;
 $header-font-weight: $global-weight-normal;
 $header-font-style: normal;
 $font-family-monospace: Consolas, 'Liberation Mono', Courier, monospace;
-$header-sizes: (
-  small: (
-    'h1': 40,
-    'h2': 32,
-    'h3': 28,
-    'h4': 24,
-    'h5': 20,
-    'h6': 16,
-  ),
-  medium: (
-    'h1': 48,
-    'h2': 32,
-    'h3': 28,
-    'h4': 24,
-    'h5': 20,
-    'h6': 16,
-  ),
-);
-$header-color: inherit;
 $header-lineheight: 1.4;
 $header-margin-bottom: 0.5rem;
+
+$header-styles: (
+  'small': (
+    'h1': ('font-size': 40, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h2': ('font-size': 32, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h3': ('font-size': 28, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h4': ('font-size': 24, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h5': ('font-size': 20, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h6': ('font-size': 16, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom)
+  ),
+  'medium': (
+    'h1': ('font-size': 48, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h2': ('font-size': 32, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h3': ('font-size': 28, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h4': ('font-size': 24, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h5': ('font-size': 20, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
+    'h6': ('font-size': 16, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom)
+  )
+);
+
+$header-color: inherit;
 $header-text-rendering: optimizeLegibility;
 $small-font-size: 90%;
 $header-small-font-color: lighten($body-font-color, 30);

--- a/source/stylesheets/utils/_settings.scss
+++ b/source/stylesheets/utils/_settings.scss
@@ -114,20 +114,20 @@ $header-margin-bottom: 0.5rem;
 
 $header-styles: (
   'small': (
-    'h1': ('font-size': 40, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h2': ('font-size': 32, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h3': ('font-size': 28, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h4': ('font-size': 24, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h5': ('font-size': 20, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h6': ('font-size': 16, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom)
+    'h1': ('font-size': 40),
+    'h2': ('font-size': 32),
+    'h3': ('font-size': 28),
+    'h4': ('font-size': 24),
+    'h5': ('font-size': 20),
+    'h6': ('font-size': 16)
   ),
   'medium': (
-    'h1': ('font-size': 48, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h2': ('font-size': 32, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h3': ('font-size': 28, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h4': ('font-size': 24, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h5': ('font-size': 20, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom),
-    'h6': ('font-size': 16, 'line-height': $header-lineheight, 'margin-top': 0, 'margin-bottom': $header-margin-bottom)
+    'h1': ('font-size': 48),
+    'h2': ('font-size': 32),
+    'h3': ('font-size': 28),
+    'h4': ('font-size': 24),
+    'h5': ('font-size': 20),
+    'h6': ('font-size': 16)
   )
 );
 


### PR DESCRIPTION
#### :tophat: Scope of work
This PR fixes deprecation warnings related to headers, as their settings changed on the last foundation version: http://foundation.zurb.com/sites/docs/typography-base.html#header-styles

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: URLs
*None*

#### :ghost: GIF (optional)
![](https://media.giphy.com/media/134BmvfC4GtQoE/giphy.gif)
