### PR TITLE
Fix: Requiring JS lines didn't match folder structure

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "foundation-sites": "~6.3.0",
+    "what-input": "~4.0.4",
     "modernizr": "~2.8.3"
   }
 }

--- a/source/javascripts/body.js
+++ b/source/javascripts/body.js
@@ -1,6 +1,6 @@
 //= require jquery/dist/jquery
-//= require what-input/what-input.min
-//= require foundation-sites/dist/foundation.min
+//= require what-input/dist/what-input.min
+//= require foundation-sites/dist/js/foundation.min
 
 //= require appendAround.js
 //= require svg4everybody.min.js

--- a/source/javascripts/body.js
+++ b/source/javascripts/body.js
@@ -1,6 +1,6 @@
 //= require jquery/dist/jquery
 //= require what-input/dist/what-input.min
-//= require foundation-sites/dist/js/foundation.min
+//= require foundation-sites/dist/js/foundation
 
 //= require appendAround.js
 //= require svg4everybody.min.js

--- a/source/javascripts/body.js
+++ b/source/javascripts/body.js
@@ -1,6 +1,6 @@
 //= require jquery/dist/jquery
-//= require what-input/dist/what-input.min
-//= require foundation-sites/dist/js/foundation.min
+//= require what-input/what-input.min
+//= require foundation-sites/dist/foundation.min
 
 //= require appendAround.js
 //= require svg4everybody.min.js


### PR DESCRIPTION
#### :tophat: Scope of work
bug fix: incorrect path for JS requires in a previous branch. Dropdowns (and other JS functions) fixed.

UPDATE: non-minified version of foundation js files to avoid minification issues in staging.

#### :pushpin: Related Issues
- Fixes #96

#### :ghost: GIF (optional)
![giphy](https://cloud.githubusercontent.com/assets/468685/21762149/777759c4-d657-11e6-9d9b-b9a9e0cc085a.gif)

