### PR TITLE
Remove local, EOT and SVG from font-face declaration

### DIFF
--- a/source/stylesheets/utils/_fontface.scss
+++ b/source/stylesheets/utils/_fontface.scss
@@ -3,12 +3,8 @@
 	font-style: normal;
 	font-weight: 400;
 	src:
-		local('Source Sans Pro'),
-		local('SourceSansPro-Regular'),
-		font-url('decidim/Source_Sans_Pro_400.eot?#iefix') format('embedded-opentype'),
-		font-url('decidim/Source_Sans_Pro_400.woff') format('woff'),
-		font-url('decidim/Source_Sans_Pro_400.woff2') format('woff2'),
-		font-url('decidim/Source_Sans_Pro_400.svg#SourceSansPro') format('svg'),
+    font-url('decidim/Source_Sans_Pro_400.woff2') format('woff2'),
+    font-url('decidim/Source_Sans_Pro_400.woff') format('woff'),
 		font-url('decidim/Source_Sans_Pro_400.ttf') format('truetype');
 }
 @font-face {
@@ -16,12 +12,8 @@
 	font-style: normal;
 	font-weight: 600;
 	src:
-		local('Source Sans Pro Semibold'),
-		local('SourceSansPro-Semibold'),
-		font-url('decidim/Source_Sans_Pro_600.eot?#iefix') format('embedded-opentype'),
+    font-url('decidim/Source_Sans_Pro_600.woff2') format('woff2'),
 		font-url('decidim/Source_Sans_Pro_600.woff') format('woff'),
-		font-url('decidim/Source_Sans_Pro_600.woff2') format('woff2'),
-		font-url('decidim/Source_Sans_Pro_600.svg#SourceSansPro') format('svg'),
 		font-url('decidim/Source_Sans_Pro_600.ttf') format('truetype');
 }
 @font-face {
@@ -29,11 +21,7 @@
 	font-style: normal;
 	font-weight: 900;
 	src:
-		local('Source Sans Pro Black'),
-		local('SourceSansPro-Black'),
-		font-url('decidim/Source_Sans_Pro_900.eot?#iefix') format('embedded-opentype'),
+    font-url('decidim/Source_Sans_Pro_900.woff2') format('woff2'),
 		font-url('decidim/Source_Sans_Pro_900.woff') format('woff'),
-		font-url('decidim/Source_Sans_Pro_900.woff2') format('woff2'),
-		font-url('decidim/Source_Sans_Pro_900.svg#SourceSansPro') format('svg'),
 		font-url('decidim/Source_Sans_Pro_900.ttf') format('truetype');
 }


### PR DESCRIPTION
#### :tophat: Scope of work
Simplification and improvements to font-face declaration.

#### :pushpin: Related Issues
- Fixes https://github.com/AjuntamentdeBarcelona/decidim-design/projects/1#card-1301445

#### :clipboard: Subtasks
- [x] Removed call for local fonts in font-face declaration, as this can easily cause conflicts with user installed fonts.
- [x] Prioritized woff2 call over woff.
- [x] Removed EOT and SVG calls. We're not supporting old browsers that need these font files, and system fonts are a good enough fallback.

#### :ghost: GIF (optional)
![](http://i.giphy.com/oI9tq086GxQ5y.gif)
