### PR TITLE
Comment reply button position

### DIFF
--- a/source/partials/_comments.html.erb
+++ b/source/partials/_comments.html.erb
@@ -370,6 +370,11 @@
         </article>
       </article>
     </article>
+    <div class="comment__additionalreply">
+      <a href="" class="comment__reply muted-link">
+        Responder
+      </a>
+    </div>
     </article>
   </div>
   <div class="show-more show-more--comment-thread">

--- a/source/stylesheets/modules/_comments.scss
+++ b/source/stylesheets/modules/_comments.scss
@@ -57,7 +57,8 @@ $comment-form-bg: $light-gray;
   }
 }
 
-.comment__footer{
+.comment__footer,
+.comment__additionalreply{
   padding: $comment-padding;
   font-size: 90%;
   @include clearfix;

--- a/source/stylesheets/modules/_comments.scss
+++ b/source/stylesheets/modules/_comments.scss
@@ -60,6 +60,7 @@ $comment-form-bg: $light-gray;
 .comment__footer{
   padding: $comment-padding;
   font-size: 90%;
+  @include clearfix;
 }
 
 .comment--nested{
@@ -72,10 +73,6 @@ $comment-form-bg: $light-gray;
   &:first-of-type{
     margin-top: 0;
   }
-}
-
-.comment__footer{
-  @include clearfix;
 }
 
 .comment__reply{
@@ -116,4 +113,3 @@ $comment-form-bg: $light-gray;
     display: block;
   }
 }
-


### PR DESCRIPTION
#### :tophat: Scope of work
New class for an additional reply button un a nested conversation. ".comment__footer" could be used as well, but "..comment__additionalreply" added for the sake of clarity.

#### :pushpin: Related Issues
- Fixes #69 

### :camera: URLs
![Additional reply at the bottom of comment card](https://cloud.githubusercontent.com/assets/468685/21805369/1f2da506-d734-11e6-9f2c-cfde19d4ec02.png)

#### :ghost: GIF (optional)
![](http://i.giphy.com/bo0eVWT3sIPio.gif)
