### PR TITLE
Fix: Incorrect bg color for off-canvas-wrapper

### DIFF
--- a/source/stylesheets/modules/_layout.scss
+++ b/source/stylesheets/modules/_layout.scss
@@ -37,7 +37,7 @@ body{
 
 //fixes for off-canvas wrappers
 .off-canvas-wrapper{
-  background-color: $white;
+  background-color: $light-gray;
 }
 
 .off-canvas-wrapper,


### PR DESCRIPTION
#### :tophat: Scope of work
A previous fix in the new Foundation integration introduced an incorrect background color. Fixing it now.

#### :ghost: GIF (optional)
![](http://i.giphy.com/aAzfMpM6xNYs0.gif)
