### PR TITLE
Process phases view (process log)

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -15,6 +15,7 @@ activesection: home
           <li><a href="/home">Home</a></li>
           <li><a href="/processes">Procesos</a></li>
           <li><a href="/info">Proceso - landing</a></li>
+          <li><a href="/phases">Proceso - Fases de proceso</a></li>
           <li><a href="/meetings">Encuentros</a></li>
           <li><a href="/meetings-callout">Encuentros pasados</a></li>
           <li><a href="/meeting-view">Vista de encuentro</a></li>

--- a/source/info.html.erb
+++ b/source/info.html.erb
@@ -150,14 +150,9 @@ activepage : info
           <h4 class="section-heading">Fotos del proceso</h4>
 					<%= partial 'partials/gallery' %>
 				</div>
-				<div class="section">
-          <h4 class="section-heading">Fases del proceso</h4>
-					<%= partial 'partials/timeline' %>
-				</div>
       </div>
     </div>
   </div>
 </main>
 
 <%= partial 'partials/template_bottom' %>
-

--- a/source/partials/_process_nav.html.erb
+++ b/source/partials/_process_nav.html.erb
@@ -2,6 +2,12 @@
   <button class="process-nav__trigger hide-for-medium"
           data-toggle="process-nav-content">
     <%= icon "caret-bottom", class: "icon--small process-nav__trigger__icon", aria_label: "Desplegar", role: "img" %>
+    <% if current_page.data.activepage == "phases" %>
+      <div class="process-nav__link">
+        <%= icon "information" %>
+        <span>Continguts</span>
+      </div>
+    <% end %>
     <% if current_page.data.activepage == "info" %>
       <div class="process-nav__link">
         <%= icon "process" %>

--- a/source/partials/_process_phase.html.erb
+++ b/source/partials/_process_phase.html.erb
@@ -28,5 +28,5 @@
     <span class="phase-date">02/06/2016 - 15/02/2016</span>
   </div>
   <!-- display this link only if phase log is enabled -->
-  <a href="" class="button tiny hollow">Ver fases</a>
+  <a href="/phases" class="button tiny hollow">Ver fases</a>
 </div>

--- a/source/partials/_process_phase.html.erb
+++ b/source/partials/_process_phase.html.erb
@@ -28,5 +28,8 @@
     <span class="phase-date">02/06/2016 - 15/02/2016</span>
   </div>
   <!-- display this link only if phase log is enabled -->
-  <a href="/phases" class="button tiny hollow">Ver fases</a>
+  <a href="/phases" class="button tiny hollow
+    <% if current_page.data.activepage == "phases" %>
+       is-active
+    <% end %>">Ver fases</a>
 </div>

--- a/source/partials/_timeline.html.erb
+++ b/source/partials/_timeline.html.erb
@@ -3,16 +3,51 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">1</span>
 		</div>
-    <div class="timeline__desc">
-      <div class="timeline__title">
-        <h6>Información</h6>
+    <div class="timeline__info">
+      <div class="timeline__header">
+        <span class="timeline__date text-small">02/06/2016 - 01/07/2016</span>
+        <h6 class="timeline__title heading6">Informació</h6>
       </div>
       <div class="timeline__content">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Atque, facilis quo maiores magnam modi ab libero praesentium blanditiis.
+          Es duran a terme dues sessions, en què s’informarà la ciutadania sobre
+          el procés, la seva voluntat, l'abast i el funcionament, així com dels
+          criteris de selecció dels àmbits i les línies estratègiques sobre les
+          quals es podrà fer proposta d’actuació, priorització i tria a partir
+          de decidim.barcelona i les trobades presencials.
+        </p>
+        <p>
+          Del 27 d’octubre de 2016 al 28 de febrer de 2017 podreu trobar a
+          diferents espais del districte un punt d’informació i de participació
+          en el procés.
         </p>
       </div>
+      <ul class="timeline__footer">
+        <li class="timeline__footer-item">
+          <a href="#" class="timeline__footer-inner">
+            <%= icon "meetings", class: "timeline__item-icon" %>
+            <span class="timeline__item-text">
+              23 trobades
+            </span>
+          </a>
+        </li>
+        <li class="timeline__footer-item">
+          <a href="#" class="timeline__footer-inner">
+            <%= icon "proposals", class: "timeline__item-icon" %>
+            <span class="timeline__item-text">
+              2500 propostes
+            </span>
+          </a>
+        </li>
+        <li class="timeline__footer-item">
+          <a href="#" class="timeline__footer-inner">
+            <%= icon "debates", class: "timeline__item-icon" %>
+            <span class="timeline__item-text">
+              20 debates
+            </span>
+          </a>
+        </li>
+      </ul>
     </div>
   </li>
 
@@ -20,16 +55,43 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">2</span>
 		</div>
-    <div class="timeline__desc">
-      <div class="timeline__title">
-        <h6>Reflexión</h6>
+    <div class="timeline__info">
+      <div class="timeline__header">
+        <span class="timeline__date text-small">02/06/2016 - 01/07/2016</span>
+        <h6 class="timeline__title heading6">Reflexió</h6>
       </div>
       <div class="timeline__content">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Atque, facilis quo maiores magnam modi ab libero praesentium blanditiis.
+          Es duran a terme dues sessions, en què s’informarà la ciutadania sobre
+          el procés, la seva voluntat, l'abast i el funcionament, així com dels
+          criteris de selecció dels àmbits i les línies estratègiques sobre les
+          quals es podrà fer proposta d’actuació, priorització i tria a partir
+          de decidim.barcelona i les trobades presencials.
+        </p>
+        <p>
+          Del 27 d’octubre de 2016 al 28 de febrer de 2017 podreu trobar a
+          diferents espais del districte un punt d’informació i de participació
+          en el procés.
         </p>
       </div>
+      <ul class="timeline__footer">
+        <li class="timeline__footer-item">
+          <a href="#" class="timeline__footer-inner">
+            <%= icon "meetings", class: "timeline__item-icon" %>
+            <span class="timeline__item-text">
+              23 trobades
+            </span>
+          </a>
+        </li>
+        <li class="timeline__footer-item">
+          <a href="#" class="timeline__footer-inner">
+            <%= icon "proposals", class: "timeline__item-icon" %>
+            <span class="timeline__item-text">
+              2500 propostes
+            </span>
+          </a>
+        </li>
+      </ul>
     </div>
   </li>
 
@@ -37,14 +99,23 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">3</span>
 		</div>
-    <div class="timeline__desc is-expanded">
-      <div class="timeline__title">
-        <h6>Propuestas</h6>
+    <div class="timeline__info">
+      <div class="timeline__header">
+        <span class="timeline__date text-small">02/06/2016 - 01/07/2016</span>
+        <h6 class="timeline__title heading6">Propostes</h6>
       </div>
       <div class="timeline__content">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Atque, facilis quo maiores magnam modi ab libero praesentium blanditiis.
+          Es duran a terme dues sessions, en què s’informarà la ciutadania sobre
+          el procés, la seva voluntat, l'abast i el funcionament, així com dels
+          criteris de selecció dels àmbits i les línies estratègiques sobre les
+          quals es podrà fer proposta d’actuació, priorització i tria a partir
+          de decidim.barcelona i les trobades presencials.
+        </p>
+        <p>
+          Del 27 d’octubre de 2016 al 28 de febrer de 2017 podreu trobar a
+          diferents espais del districte un punt d’informació i de participació
+          en el procés.
         </p>
       </div>
     </div>
@@ -53,14 +124,23 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">4</span>
 		</div>
-    <div class="timeline__desc">
-      <div class="timeline__title">
-        <h6>Concreción</h6>
+    <div class="timeline__info">
+      <div class="timeline__header">
+        <span class="timeline__date text-small">02/06/2016 - 01/07/2016</span>
+        <h6 class="timeline__title heading6">Concreción</h6>
       </div>
       <div class="timeline__content">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Atque, facilis quo maiores magnam modi ab libero praesentium blanditiis.
+          Es duran a terme dues sessions, en què s’informarà la ciutadania sobre
+          el procés, la seva voluntat, l'abast i el funcionament, així com dels
+          criteris de selecció dels àmbits i les línies estratègiques sobre les
+          quals es podrà fer proposta d’actuació, priorització i tria a partir
+          de decidim.barcelona i les trobades presencials.
+        </p>
+        <p>
+          Del 27 d’octubre de 2016 al 28 de febrer de 2017 podreu trobar a
+          diferents espais del districte un punt d’informació i de participació
+          en el procés.
         </p>
       </div>
     </div>
@@ -69,14 +149,23 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">5</span>
 		</div>
-    <div class="timeline__desc">
-      <div class="timeline__title">
-        <h6>Retorno</h6>
+    <div class="timeline__info">
+      <div class="timeline__header">
+        <span class="timeline__date text-small">02/06/2016 - 01/07/2016</span>
+        <h6 class="timeline__title heading6">Retorno</h6>
       </div>
       <div class="timeline__content">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Atque, facilis quo maiores magnam modi ab libero praesentium blanditiis.
+          Es duran a terme dues sessions, en què s’informarà la ciutadania sobre
+          el procés, la seva voluntat, l'abast i el funcionament, així com dels
+          criteris de selecció dels àmbits i les línies estratègiques sobre les
+          quals es podrà fer proposta d’actuació, priorització i tria a partir
+          de decidim.barcelona i les trobades presencials.
+        </p>
+        <p>
+          Del 27 d’octubre de 2016 al 28 de febrer de 2017 podreu trobar a
+          diferents espais del districte un punt d’informació i de participació
+          en el procés.
         </p>
       </div>
     </div>
@@ -85,14 +174,23 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">6</span>
 		</div>
-    <div class="timeline__desc">
-      <div class="timeline__title">
-        <h6>Seguimiento</h6>
+    <div class="timeline__info">
+      <div class="timeline__header">
+        <span class="timeline__date text-small">02/06/2016 - 01/07/2016</span>
+        <h6 class="timeline__title heading6">Seguimiento</h6>
       </div>
       <div class="timeline__content">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Atque, facilis quo maiores magnam modi ab libero praesentium blanditiis.
+          Es duran a terme dues sessions, en què s’informarà la ciutadania sobre
+          el procés, la seva voluntat, l'abast i el funcionament, així com dels
+          criteris de selecció dels àmbits i les línies estratègiques sobre les
+          quals es podrà fer proposta d’actuació, priorització i tria a partir
+          de decidim.barcelona i les trobades presencials.
+        </p>
+        <p>
+          Del 27 d’octubre de 2016 al 28 de febrer de 2017 podreu trobar a
+          diferents espais del districte un punt d’informació i de participació
+          en el procés.
         </p>
       </div>
     </div>

--- a/source/partials/_timeline.html.erb
+++ b/source/partials/_timeline.html.erb
@@ -3,12 +3,10 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">1</span>
 		</div>
-    <div class="timeline__desc" id="timeline-info" data-toggler=".is-expanded">
-      <a class="timeline__title" data-toggle="timeline-info">
-        <h6>Información
-          <%= icon "caret-bottom", class: "icon--small timeline__title__icon", aria_label: "Desplegar", role: "img" %>
-        </h6>
-      </a>
+    <div class="timeline__desc">
+      <div class="timeline__title">
+        <h6>Información</h6>
+      </div>
       <div class="timeline__content">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -22,12 +20,10 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">2</span>
 		</div>
-    <div class="timeline__desc" id="timeline-refl" data-toggler=".is-expanded">
-      <a class="timeline__title" data-toggle="timeline-refl">
-        <h6>Reflexión
-          <%= icon "caret-bottom", class: "icon--small timeline__title__icon", aria_label: "Desplegar", role: "img" %>
-        </h6>
-      </a>
+    <div class="timeline__desc">
+      <div class="timeline__title">
+        <h6>Reflexión</h6>
+      </div>
       <div class="timeline__content">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -41,12 +37,10 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">3</span>
 		</div>
-    <div class="timeline__desc is-expanded" id="timeline-prop" data-toggler=".is-expanded">
-      <a class="timeline__title" data-toggle="timeline-prop">
-        <h6>Propuestas
-          <%= icon "caret-bottom", class: "icon--small timeline__title__icon", aria_label: "Desplegar", role: "img" %>
-        </h6>
-      </a>
+    <div class="timeline__desc is-expanded">
+      <div class="timeline__title">
+        <h6>Propuestas</h6>
+      </div>
       <div class="timeline__content">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -59,12 +53,10 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">4</span>
 		</div>
-    <div class="timeline__desc" id="timeline-conc" data-toggler=".is-expanded">
-      <a class="timeline__title" data-toggle="timeline-conc">
-        <h6>Concreción
-          <%= icon "caret-bottom", class: "icon--small timeline__title__icon", aria_label: "Desplegar", role: "img" %>
-        </h6>
-      </a>
+    <div class="timeline__desc">
+      <div class="timeline__title">
+        <h6>Concreción</h6>
+      </div>
       <div class="timeline__content">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -77,12 +69,10 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">5</span>
 		</div>
-    <div class="timeline__desc" id="timeline-return" data-toggler=".is-expanded">
-      <a class="timeline__title" data-toggle="timeline-return">
-        <h6>Retorno
-          <%= icon "caret-bottom", class: "icon--small timeline__title__icon", aria_label: "Desplegar", role: "img" %>
-        </h6>
-      </a>
+    <div class="timeline__desc">
+      <div class="timeline__title">
+        <h6>Retorno</h6>
+      </div>
       <div class="timeline__content">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -95,12 +85,10 @@
     <div class="timeline__phase">
 		  <span class="timeline__phase__number">6</span>
 		</div>
-    <div class="timeline__desc" id="timeline-follow" data-toggler=".is-expanded">
-      <a class="timeline__title" data-toggle="timeline-follow">
-        <h6>Seguimiento
-          <%= icon "caret-bottom", class: "icon--small timeline__title__icon", aria_label: "Desplegar", role: "img" %>
-        </h6>
-      </a>
+    <div class="timeline__desc">
+      <div class="timeline__title">
+        <h6>Seguimiento</h6>
+      </div>
       <div class="timeline__content">
         <p>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit.

--- a/source/phases.html.erb
+++ b/source/phases.html.erb
@@ -1,0 +1,23 @@
+---
+title: Proceso -- Decidim Barcelona
+activesection: processes
+activepage : phases
+---
+
+<%= partial 'partials/template_top' %>
+
+<main class="wrapper">
+  <%= partial 'partials/process_header' %>
+  <div class="row column">
+    <div class="row">
+      <div class="columns large-8">
+				<div class="section">
+          <h4 class="section-heading">Fases del proceso</h4>
+					<%= partial 'partials/timeline' %>
+				</div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<%= partial 'partials/template_bottom' %>

--- a/source/phases.html.erb
+++ b/source/phases.html.erb
@@ -10,7 +10,7 @@ activepage : phases
   <%= partial 'partials/process_header' %>
   <div class="row column">
     <div class="row">
-      <div class="columns large-8">
+      <div class="columns mediumlarge-9 large-7">
 				<div class="section">
           <h4 class="section-heading">Fases del proceso</h4>
 					<%= partial 'partials/timeline' %>

--- a/source/stylesheets/modules/_process-header.scss
+++ b/source/stylesheets/modules/_process-header.scss
@@ -51,7 +51,8 @@
     margin-bottom: 0;
     color: $white;
     border-color: $white;
-    &:hover{
+    &:hover,
+    &.is-active{
       color: $primary;
       border-color: $primary;
     }

--- a/source/stylesheets/modules/_timeline.scss
+++ b/source/stylesheets/modules/_timeline.scss
@@ -13,7 +13,6 @@ $timeline-padding: 1rem;
 .timeline {
 	list-style: none;
   margin: 2rem 0 0;
-	transition: all .4s ease;
 }
 
 .timeline__item {
@@ -27,9 +26,6 @@ $timeline-padding: 1rem;
 		left: 1rem;
 		top: 0;
 		position: absolute;
-    @include breakpoint(medium){
-      left: 50%;
-    }
 	}
 	&:after {
 		content: "";
@@ -56,9 +52,6 @@ $timeline-padding: 1rem;
   background: $timeline-color;
   border: 2px solid $white;
   box-shadow: 0 0 0 1px $medium-gray;
-  @include breakpoint(medium){
-    left: 50%;
-  }
 }
 
 .timeline__phase__number{
@@ -78,52 +71,10 @@ $timeline-padding: 1rem;
   width: calc(100% - 45px);
   float: right;
   padding: $timeline-padding/2 $timeline-padding 0;
-  border: 1px solid $timeline-color;
-  border-radius: $global-radius;
-  transition: all .3s ease;
-  transform: translateY(-.4rem);
-  @include breakpoint(medium){
-    width: 45%;
-    float: left;
-  }
-  &:before {
-    content: '';
-    position: absolute;
-    right: 100%;
-    top: .6rem;
-    width: 0;
-    height: 0;
-    border-top: 10px solid transparent;
-    border-bottom: 10px solid transparent;
-    border-right: 10px solid $timeline-color;
-    @include breakpoint(medium){
-      left: 100%;
-      border-right: 0;
-      border-left: 10px solid $timeline-color;
-    }
-  }
-  .timeline__item:nth-of-type(even) &{
-    float: right;
-    &:before{
-      content: '';
-      right: 100%;
-      left: inherit;
-      border-left: 0;
-      border-right: 10px solid $timeline-color;
-    }
-  }
 }
 
 .timeline__title{
   display: block;
-  padding: $timeline-padding/2 $timeline-padding;
-  background: $timeline-color;
-  color: $white;
-  margin: (-$timeline-padding/2) (-$timeline-padding) 0 (-$timeline-padding);
-  &:hover,
-  &:active{
-    color: $white;
-  }
   > h6{
     margin-bottom: 0;
   }
@@ -132,22 +83,6 @@ $timeline-padding: 1rem;
 .timeline__title__icon{
   margin-left: 3px;
   vertical-align: middle;
-}
-
-.timeline__content{
-  display: none;
-  padding-top: $timeline-padding/2;
-}
-
-/* Collapse styles */
-
-.timeline__desc.is-expanded{
-  .timeline__content{
-    display: block;
-  }
-  .timeline__title__icon{
-    transform: rotate(180deg);
-  }
 }
 
 /* Inactive timeline */
@@ -167,19 +102,6 @@ $timeline-padding: 1rem;
   }
   .timeline__phase__number{
     text-shadow: 0 1px 2px rgba(black, 0.1);
-  }
-  .timeline__desc{
-    border-color: $timeline-inactive-color;
-    &:before{
-      border-right-color: $timeline-inactive-color;
-      @include breakpoint(medium){
-        border-left-color: $timeline-inactive-color;
-      }
-    }
-  }
-  .timeline__title{
-    background: $timeline-inactive-color;
-    color: inherit;
   }
 }
 .timeline__item:nth-of-type(even).timeline__item--inactive{

--- a/source/stylesheets/modules/_timeline.scss
+++ b/source/stylesheets/modules/_timeline.scss
@@ -66,23 +66,88 @@ $timeline-padding: 1rem;
   margin-top: -1px;
 }
 
-.timeline__desc{
+.timeline__info{
   width: 90%;
   width: calc(100% - 45px);
   float: right;
-  padding: $timeline-padding/2 $timeline-padding 0;
+  background-color: $white;
+  border: $border;
+  .timeline__item--current &{
+    border-color: $timeline-color;
+  }
+}
+
+.timeline__header{
+  background: $medium-gray;
+  padding: $timeline-padding/2 $timeline-padding;
+  .timeline__item--current &{
+    background-color: $timeline-color;
+    color: $white;
+  }
+}
+
+.timeline__date{
+  color: $muted;
+  .timeline__item--current &{
+    color: rgba($white,.8);
+  }
 }
 
 .timeline__title{
-  display: block;
-  > h6{
+  margin-bottom: 0;
+}
+
+.timeline__content{
+  padding: $timeline-padding;
+  :last-child{
     margin-bottom: 0;
   }
 }
 
-.timeline__title__icon{
-  margin-left: 3px;
-  vertical-align: middle;
+.timeline__footer{
+  list-style: none;
+  margin: 0;
+  border-top: $border;
+  @include breakpoint(medium){
+    display: flex;
+    flex-wrap: wrap;
+  }
+}
+
+.timeline__footer-item{
+  flex-grow: 1;
+  text-align: center;
+  padding: .5em;
+  border-bottom: $border;
+  &:last-child{
+    border-bottom: 0;
+  }
+  @include breakpoint(medium){
+    border-bottom: 0;
+    border-right: $border;
+    &:last-child{
+      border-right: 0;
+    }
+  }
+}
+
+.timeline__footer-inner{
+  display: block;
+}
+
+.timeline__item-icon{
+  width: 1.5em;
+  height: 1.5em;
+}
+
+.timeline__item-text{
+  display: block;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 90%;
+  color: $body-font-color;
+  font-weight: 600;
+  line-height: 1;
 }
 
 /* Inactive timeline */
@@ -102,10 +167,5 @@ $timeline-padding: 1rem;
   }
   .timeline__phase__number{
     text-shadow: 0 1px 2px rgba(black, 0.1);
-  }
-}
-.timeline__item:nth-of-type(even).timeline__item--inactive{
-  .timeline__desc:before{
-    border-right-color: $timeline-inactive-color;
   }
 }


### PR DESCRIPTION
#### :tophat: Scope of work
In the new process structure, phases info is out of the navigation and lives in a separate page, the log. These styles and structure completely replace the old timeline shown before in the process homepage.

#### :pushpin: Related Issues
- Fixes https://github.com/AjuntamentdeBarcelona/decidim-design/projects/1#card-1301319

### :camera: URLs
![Phases view](https://cloud.githubusercontent.com/assets/468685/21884370/512c0ee6-d8b3-11e6-87f3-0f60e8141cfb.png)

#### :ghost: GIF (optional)
![](http://i.giphy.com/26grzJGhvpjH1vljq.gif)
