### PR TITLE
Styles for active filters tags

### DIFF
--- a/source/partials/_filter_tags.erb
+++ b/source/partials/_filter_tags.erb
@@ -1,0 +1,15 @@
+<div class="row collapse filter-tags">
+  <strong class="filter-tags__title">Filtres actius:</strong>
+  <span class="filter-tag">
+    <span class="filter-tag__label">Fase 2</span>
+    <a href="#" class="filter-tag__close">
+      <%= icon "x", class:"icon--small", aria_label:"Treure" %>
+    </a>
+  </span>
+  <span class="filter-tag">
+    <span class="filter-tag__label">Ajuntament</span>
+    <a href="#" class="filter-tag__close">
+      <%= icon "x", class:"icon--small", aria_label:"Treure" %>
+    </a>
+  </span>
+</div>

--- a/source/proposals-with-filters.html.erb
+++ b/source/proposals-with-filters.html.erb
@@ -1,0 +1,427 @@
+---
+title: Proceso -- Decidim Barcelona
+activesection: processes
+activepage : proposals
+---
+
+<%= partial 'partials/template_top' %>
+
+<main class="wrapper">
+  <%= partial 'partials/process_header' %>
+  <div class="row columns">
+    <h2 class="section-heading">168 propuestas abiertas</h2>
+  </div>
+  <div class="row">
+    <div class="columns mediumlarge-4 large-3">
+      <%= partial 'partials/filters_small_view' %>
+      <div class="card card--secondary show-for-mediumlarge">
+        <%= partial 'partials/filters' %>
+      </div>
+    </div>
+    <div class="columns mediumlarge-8 large-9">
+      <%= partial 'partials/filter_tags' %>
+      <%= partial 'partials/order_by' %>
+      <div class="row small-up-1 medium-up-2 mediumlarge-up-1 large-up-2 card-grid">
+        <div class="column">
+          <article class="card card--proposal">
+            <div class="card__content">
+              <div class="card__header">
+                <a href="/proposal-view" class="card__link">
+                  <h5 class="card__title">
+                    Creació d'aules ambientals al Parc del Clot
+                  </h5>
+                </a>
+                <div class="card__author author-data author-data--small">
+                  <div class="author-data__main">
+                    <div class="author author--inline">
+                      <a href="#" class="author__avatar author__avatar--small">
+                        <img src="/images/demo-avatar.jpg" alt="">
+                      </a>
+                      <a href="#" class="author__name">
+                        Ajuntament de Barcelona
+                      </a>
+                      01/08/2016
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p>
+                Implementar la instal·lació d’àrees
+                estratègiques de càrrega i descàrrega per garantir uns
+                 fluxos de mobilitat sostenibles i respectuosos.</p>
+              <ul class="tags tags--proposal">
+                <li><a href="">transició ecológica</a></li>
+                <li><a href="">mobilitat sostenible</a></li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <div class="card__support">
+                <div class="card__support__data">
+                  <span class="card__support__number">27</span>suports
+                  <div class="popularity popularity--level5">
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                  </div>
+                </div>
+                <button class="card__button button small"
+                  data-toggle="loginModal">
+                  Donar suport
+                </button>
+              </div>
+            </div>
+          </article>
+          <div class="reveal" id="loginModal" data-reveal>
+            <div class="reveal__header">
+              <h3 class="reveal__title">Por favor, inicia sesión</h3>
+              <button class="close-button" data-close aria-label="Close modal"
+                type="button">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="row">
+              <div class="columns medium-8 medium-centered">
+                <form class="register-form">
+                  <div>
+                    <div>
+                      <label>Adreça electrònica
+                        <input type="email" placeholder="exemple@domini.com">
+                      </label>
+                    </div>
+                    <div>
+                      <label>Contrasenya
+                        <input type="password" placeholder="Contrasenya">
+                      </label>
+                    </div>
+                  </div>
+                  <fieldset>
+                    <label>
+                      <input type="checkbox">
+                      Recorda'm
+                    </label>
+                  </fieldset>
+                  <button type="submit" class="button expanded">Entra</button>
+                </form>
+                <p class="text-center">
+                  Ets nou a la plataforma? <a href="#">Registra't</a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="column">
+          <article class="card card--proposal">
+            <div class="card__content">
+              <div class="card__header">
+                <a href="/proposal-view-rejected" class="card__link">
+                  <h5 class="card__title">
+                    Creació d'aules ambientals i d'estudi al Parc del Clot
+                  </h5>
+                </a>
+                <div class="card__author author-data author-data--small">
+                  <div class="author-data__main">
+                    <div class="author author--inline">
+                      <a href="#" class="author__avatar author__avatar--small">
+                        <img src="/images/demo-avatar.jpg" alt="">
+                      </a>
+                      <a href="#" class="author__name">
+                        Ajuntament de Barcelona
+                      </a>
+                      01/08/2016
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p>
+                Implementar la instal·lació d’àrees
+                estratègiques de càrrega i descàrrega per garantir uns
+                 fluxos de mobilitat sostenibles i respectuosos i descàrrega
+                per garantir uns fluxos de mobilitat sostenibles i
+                respectuosos.</p>
+              <ul class="tags tags--proposal">
+                <li><a href="">transició ecológica</a></li>
+                <li><a href="">mobilitat sostenible</a></li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <div class="card__support">
+                <div class="card__support__data">
+                  <span class="card__support__number">27</span>suports
+                  <div class="popularity popularity--level3">
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                  </div>
+                </div>
+                <button class="card__button button small success">
+                  Donant suport
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+        <div class="column">
+          <article class="card card--proposal">
+            <div class="card__content">
+              <div class="card__header">
+                <a href="/proposal-view" class="card__link">
+                  <h5 class="card__title">
+                    Creació d'aules ambientals al Parc del Clot
+                  </h5>
+                </a>
+                <div class="card__author author-data author-data--small">
+                  <div class="author-data__main">
+                    <div class="author author--inline">
+                      <a href="#" class="author__avatar author__avatar--small">
+                        <img src="/images/demo-avatar.jpg" alt="">
+                      </a>
+                      <a href="#" class="author__name">
+                        Ajuntament de Barcelona
+                      </a>
+                      01/08/2016
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p>
+                Implementar la instal·lació d’àrees
+                estratègiques de càrrega i descàrrega per garantir uns
+                 fluxos de mobilitat sostenibles i respectuosos.</p>
+              <ul class="tags tags--proposal">
+                <li><a href="">transició ecológica</a></li>
+                <li><a href="">mobilitat sostenible</a></li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <div class="card__support">
+                <div class="card__support__data">
+                  <span class="card__support__number">27</span>suports
+                  <div class="popularity popularity--level1">
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                  </div>
+                </div>
+                <button class="card__button button small">
+                  Donar suport
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+        <div class="column">
+          <article class="card card--proposal">
+            <div class="card__content">
+              <div class="card__header">
+                <a href="/proposal-view" class="card__link">
+                  <h5 class="card__title">
+                    Creació d'aules ambientals al Parc del Clot
+                  </h5>
+                </a>
+                <div class="card__author author-data author-data--small">
+                  <div class="author-data__main">
+                    <div class="author author--inline">
+                      <a href="#" class="author__avatar author__avatar--small">
+                        <img src="/images/demo-avatar.jpg" alt="">
+                      </a>
+                      <a href="#" class="author__name">
+                        Ajuntament de Barcelona
+                      </a>
+                      01/08/2016
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p>
+                Implementar la instal·lació d’àrees
+                estratègiques de càrrega i descàrrega per garantir uns
+                 fluxos de mobilitat sostenibles i respectuosos.</p>
+              <ul class="tags tags--proposal">
+                <li><a href="">transició ecológica</a></li>
+                <li><a href="">mobilitat sostenible</a></li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <div class="card__support">
+                <div class="card__support__data">
+                  <span class="card__support__number">27</span>suports
+                  <div class="popularity popularity--level4">
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                  </div>
+                </div>
+                <button class="card__button button small">
+                  Donar suport
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+        <div class="column">
+          <article class="card card--proposal">
+            <div class="card__content">
+              <div class="card__header">
+                <a href="/proposal-view" class="card__link">
+                  <h5 class="card__title">
+                    Creació d'aules ambientals al Parc del Clot
+                  </h5>
+                </a>
+                <div class="card__author author-data author-data--small">
+                  <div class="author-data__main">
+                    <div class="author author--inline">
+                      <a href="#" class="author__avatar author__avatar--small">
+                        <img src="/images/demo-avatar.jpg" alt="">
+                      </a>
+                      <a href="#" class="author__name">
+                        Ajuntament de Barcelona
+                      </a>
+                      01/08/2016
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p>
+                Implementar la instal·lació d’àrees
+                estratègiques de càrrega i descàrrega per garantir uns
+                 fluxos de mobilitat sostenibles i respectuosos.</p>
+              <ul class="tags tags--proposal">
+                <li><a href="">transició ecológica</a></li>
+                <li><a href="">mobilitat sostenible</a></li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <div class="card__support">
+                <div class="card__support__data">
+                  <span class="card__support__number">0</span>suports
+                  <div class="popularity">
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                  </div>
+                </div>
+                <button class="card__button button small">
+                  Donar suport
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+        <div class="column">
+          <article class="card card--proposal">
+            <div class="card__content">
+              <div class="card__header">
+                <a href="/proposal-view" class="card__link">
+                  <h5 class="card__title">
+                    Creació d'aules ambientals i d'estudi al Parc del Clot
+                  </h5>
+                </a>
+                <div class="card__author author-data author-data--small">
+                  <div class="author-data__main">
+                    <div class="author author--inline">
+                      <a href="#" class="author__avatar author__avatar--small">
+                        <img src="/images/demo-avatar.jpg" alt="">
+                      </a>
+                      <a href="#" class="author__name">
+                        Ajuntament de Barcelona
+                      </a>
+                      01/08/2016
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p>
+                Implementar la instal·lació d’àrees
+                estratègiques de càrrega i descàrrega per garantir uns
+                 fluxos de mobilitat sostenibles i respectuosos.</p>
+              <ul class="tags tags--proposal">
+                <li><a href="">transició ecológica</a></li>
+                <li><a href="">mobilitat sostenible</a></li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <div class="card__support">
+                <div class="card__support__data">
+                  <span class="card__support__number">27</span>suports
+                  <div class="popularity popularity--level2">
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                  </div>
+                </div>
+                <button class="card__button button small">
+                  Donar suport
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+        <div class="column">
+          <article class="card card--proposal">
+            <div class="card__content">
+              <div class="card__header">
+                <a href="/proposal-view" class="card__link">
+                  <h5 class="card__title">
+                    Creació d'aules ambientals al Parc del Clot
+                  </h5>
+                </a>
+                <div class="card__author author-data author-data--small">
+                  <div class="author-data__main">
+                    <div class="author author--inline">
+                      <a href="#" class="author__avatar author__avatar--small">
+                        <img src="/images/demo-avatar.jpg" alt="">
+                      </a>
+                      <a href="#" class="author__name">
+                        Ajuntament de Barcelona
+                      </a>
+                      01/08/2016
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p>
+                Implementar la instal·lació d’àrees
+                estratègiques de càrrega i descàrrega per garantir uns
+                 fluxos de mobilitat sostenibles i respectuosos.</p>
+              <ul class="tags tags--proposal">
+                <li><a href="">transició ecológica</a></li>
+                <li><a href="">mobilitat sostenible</a></li>
+              </ul>
+            </div>
+            <div class="card__footer">
+              <div class="card__support">
+                <div class="card__support__data">
+                  <span class="card__support__number">27</span>suports
+                  <div class="popularity popularity--level5">
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                    <span class="popularity__item"></span>
+                  </div>
+                </div>
+                <button class="card__button button small">
+                  Donar suport
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<%= partial 'partials/template_bottom' %>

--- a/source/stylesheets/modules/_filter-tags.scss
+++ b/source/stylesheets/modules/_filter-tags.scss
@@ -5,7 +5,7 @@ $filter-tags-padding: .2rem;
 
 /* Filter tags */
 .filter-tags__title{
-  margin-right: $filter-tags-padding*2;
+  margin-right: $filter-tags-padding * 2;
 }
 .filter-tags{
   margin-bottom: 1rem - $filter-tags-padding;
@@ -14,8 +14,8 @@ $filter-tags-padding: .2rem;
   display: inline-block;
   background-color: $filter-tags-color;
   border: $border;
-  padding: $filter-tags-padding $filter-tags-padding*2;
-  margin-right: $filter-tags-padding*2;
+  padding: $filter-tags-padding $filter-tags-padding * 2;
+  margin-right: $filter-tags-padding * 2;
   margin-bottom: $filter-tags-padding;
 }
 .filter-tag__close{

--- a/source/stylesheets/modules/_filter-tags.scss
+++ b/source/stylesheets/modules/_filter-tags.scss
@@ -1,0 +1,24 @@
+//Variables
+
+$filter-tags-color: $light-gray-dark;
+$filter-tags-padding: .2rem;
+
+/* Filter tags */
+.filter-tags__title{
+  margin-right: $filter-tags-padding*2;
+}
+.filter-tags{
+  margin-bottom: 1rem - $filter-tags-padding;
+}
+.filter-tag{
+  display: inline-block;
+  background-color: $filter-tags-color;
+  border: $border;
+  padding: $filter-tags-padding $filter-tags-padding*2;
+  margin-right: $filter-tags-padding*2;
+  margin-bottom: $filter-tags-padding;
+}
+.filter-tag__close{
+  padding-left: .5rem;
+  color: $body-font-color;
+}


### PR DESCRIPTION
#### :tophat: Scope of work
New styles for filter tags. These tags will show the user when a filter is in effect, either because she used the sidebar to filter the results, or because she followed a pre-filtered link (ie, "View Phase 2 proposals").

#### :pushpin: Related Issues
- Related to https://github.com/AjuntamentdeBarcelona/decidim-design/projects/1#card-1335779

#### :clipboard: Subtasks
- [x] Styles for removable tags
- [x] New demo page: proposals-with-filters.html

### :camera: URLs
![Filter tags](https://cloud.githubusercontent.com/assets/466018/21889206/108a32f4-d8c8-11e6-8699-e34b3d1cbe49.png)

#### :ghost: GIF (optional)
![](http://i.giphy.com/3o6Ei0fWOw1iQ79d0A.gif)
