### PR TITLE
Separate core modules inside `_decidim.sass`

### DIFF
--- a/source/stylesheets/_decidim.scss
+++ b/source/stylesheets/_decidim.scss
@@ -1,0 +1,9 @@
+//@import compass
+@import "variables";
+@import "utils/*";
+
+@import "foundation";
+@include foundation-everything;
+
+@import "modules/modules";
+@import "layouts/*";

--- a/source/stylesheets/application.scss
+++ b/source/stylesheets/application.scss
@@ -1,12 +1,3 @@
-//@import compass
-@import "variables";
-@import "utils/*";
-
-@import "foundation";
-@include foundation-everything;
-
-@import "modules/modules";
+@import "decidim";
 @import "features/features";
-@import "layouts/*";
-
 @import "skins/barcelona";


### PR DESCRIPTION
#### :tophat: Scope of work

This separates core modules inside `_decidim.sass`. Features and skins are optional and should only be required as an *example*.

The idea behind this is that the whole folder except `features`, `skins` and `application.sass` can then be directly copied inside `decidim`.

#### :pushpin: Related Issues
* https://github.com/AjuntamentdeBarcelona/decidim/pull/601

#### :clipboard: Subtasks
*None*.

### :camera: URLs
*None*

#### :ghost: GIF (optional)
![](https://media.giphy.com/media/tg6mPR35KIN8I/source.gif)
