### PR TITLE
Style buttons with the `disabled` attribute

### DIFF
--- a/source/stylesheets/modules/_buttons.scss
+++ b/source/stylesheets/modules/_buttons.scss
@@ -9,6 +9,11 @@
     padding-top: .25rem;
     padding-bottom: .25rem;
   }
+
+  &:disabled{
+    @extend .button;
+    @extend .button.disabled;
+  }
 }
 
 


### PR DESCRIPTION
#### :tophat: Scope of work
This extends all buttons with the `disabled` attribute with the styles from `.button.disabled`. Without it, they are *completely transparent*, due to styling done in forms.

This could also be achieved adding the `.disabled` class when needed, but using the attribute is more standards-compliant and works out of the box with many libraries (like Rails' UJS).

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: URLs
*None*

#### :ghost: GIF (optional)
![](https://media.giphy.com/media/5Z1ozMaig2M4o/giphy.gif)
