### PR TITLE
Different badges styles

### DIFF
--- a/source/pattern-library.html.erb
+++ b/source/pattern-library.html.erb
@@ -27,6 +27,9 @@ activeuser: logged
                 <li class="tabs-title">
                   <a href="#patternCards">Tarjetas y contenedores</a>
                 </li>
+                <li class="tabs-title">
+                  <a href="#patternMarkers">Marcadores</a>
+                </li>
               </ul>
             </div>
           </div>
@@ -684,6 +687,30 @@ activeuser: logged
                     </div>
                   </div>
 
+                </div>
+
+                <div class="tabs-panel" id="patternMarkers">
+                  <h2 class="section-heading">Badges de usuario</h2>
+                  <p>Lorena Ipsum
+                    <span class="label label--small label--basic">
+                      Regidora
+                    </span>
+                  </p>
+                  <p>Dolores Sit Amet
+                    <span class="label label--small label--highlight">
+                      Alcaldessa
+                    </span>
+                  </p>
+                  <p>Consectetur Adipiscing
+                    <span class="label label--small label--admin">
+                      Admin
+                    </span>
+                  </p>
+                  <p>Usuaria Verificada
+                    <span class="label label--small label--basic">
+                      <%= icon "check", class: "icon--small" %>
+                    </span>
+                  </p>
                 </div>
 
               </div>

--- a/source/stylesheets/modules/_status-labels.scss
+++ b/source/stylesheets/modules/_status-labels.scss
@@ -1,6 +1,12 @@
 .label--basic{
   background-color: lighten($dark-gray, 60);
 }
+.label--highlight{
+  background-color: $secondary;
+}
+.label--admin{
+  background-color: $primary;
+}
 
 .proposal-status{
   float: left;


### PR DESCRIPTION
#### :tophat: Scope of work
Added some new badges styles to use with different user types. Apart from `.label--basic`we now have `.label--highlight` and `.label--admin`. 

#### :pushpin: Related Issues
- Fixes #84 

#### :clipboard: Subtasks
- [x] New badges classes and styles.
- [x] New badges are documented in the pattern library.

### :camera: URLs
![badges](https://cloud.githubusercontent.com/assets/466018/22289566/9666ccfa-e2fc-11e6-9d88-652a91ffc895.png)


#### :ghost: GIF (optional)
![](http://i.giphy.com/26uflQItp3QyLHX56.gif)
