### PR TITLE
Sass tint function fix

### DIFF
--- a/source/stylesheets/features/budget/_budget-list.scss
+++ b/source/stylesheets/features/budget/_budget-list.scss
@@ -11,7 +11,7 @@
   }
 }
 .budget-list__data--added{
-  background-color: mix(white, $success, 80%);
+  background-color: tint($success, 80%);
 }
 
 .budget-list__number{

--- a/source/stylesheets/features/budget/_budget-list.scss
+++ b/source/stylesheets/features/budget/_budget-list.scss
@@ -11,7 +11,7 @@
   }
 }
 .budget-list__data--added{
-  background-color: tint($success, 80%);
+  background-color: mix(white, $success, 80%);
 
 }
 

--- a/source/stylesheets/features/budget/_budget-list.scss
+++ b/source/stylesheets/features/budget/_budget-list.scss
@@ -12,7 +12,6 @@
 }
 .budget-list__data--added{
   background-color: mix(white, $success, 80%);
-
 }
 
 .budget-list__number{

--- a/source/stylesheets/utils/_mixins.scss
+++ b/source/stylesheets/utils/_mixins.scss
@@ -30,8 +30,12 @@
   background: rgba(#27353B, 0.6);
 }
 
-// Usefull Compass mixins
+/// Slightly lighten a color
+@function tint($color, $percentage) {
+  @return mix(white, $color, $percentage);
+}
 
-// +font-face
-// +ellipsis
-// +clearfix
+/// Slightly darken a color
+@function shade($color, $percentage) {
+  @return mix(black, $color, $percentage);
+}


### PR DESCRIPTION
#### :tophat: Scope of work
Fixed a line where a Compass function (tint) was being used, replaced with the Sass native ("mix").
Also functions shade and tint added for future needs.

#### :ghost: GIF (optional)
![](http://i.giphy.com/l4lQZA7mIIjdK.gif)
