### PR TITLE
:hover styles in disabled hollow buttons fixed

### DIFF
--- a/source/stylesheets/modules/_buttons.scss
+++ b/source/stylesheets/modules/_buttons.scss
@@ -9,12 +9,28 @@
     padding-top: .25rem;
     padding-bottom: .25rem;
   }
+}
 
-  &:disabled{
-    @extend .button;
-    @extend .button.disabled;
+// Overwrite Foundation hover styles in hollow disabled buttons
+.button.hollow:disabled:hover,
+.button.hollow.disabled:hover{
+  background-color: transparent;
+  border-color: inherit;
+  color: $primary;
+  &.secondary{
+    color: $secondary;
+  }
+  &.success{
+    color: $success;
+  }
+  &.alert{
+    color: $alert;
+  }
+  &.warning{
+    color: $warning;
   }
 }
+
 
 
 /*Extra buttons styles*/


### PR DESCRIPTION
#### :tophat: Scope of work
:hover styles in disabled hollow buttons fixed (Foundation override).

#### :pushpin: Related Issues
- Fixes #137