### PR TITLE
Attribute for dropdown menu to avoid Foundation bug with menu links not being followed in touch interactions

### DIFF
--- a/source/partials/_order_by.html.erb
+++ b/source/partials/_order_by.html.erb
@@ -1,6 +1,6 @@
 <div class="row collapse order-by">
   <div class="order-by__dropdown">
-    <span class="order-by__text">Ordenar 
+    <span class="order-by__text">Ordenar
       <!--<strong>168
       <% if current_page.data.activepage == "actions" %>
        actuacions
@@ -16,7 +16,7 @@
     <% end %>
       </strong>-->
       per:</span>
-    <ul class="dropdown menu" data-dropdown-menu>
+    <ul class="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
       <li>
         <a href="#">Pesos</a>
         <ul class="menu">

--- a/source/partials/_order_by_comments.html.erb
+++ b/source/partials/_order_by_comments.html.erb
@@ -1,5 +1,5 @@
 <div class="row collapse order-by">
-  <h2 class="order-by__text section-heading">132 comentaris - 
+  <h2 class="order-by__text section-heading">132 comentaris -
     <span class="order-by__tabs">
 			<a href="#" class="order-by__tab">a favor</a>
 			<a href="#" class="order-by__tab">en contra</a>
@@ -7,7 +7,7 @@
   </h2>
   <div class="order-by__dropdown order-by__dropdown--right">
     <span class="order-by__text">Ordenar per:</span>
-    <ul class="dropdown menu" data-dropdown-menu>
+    <ul class="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
       <li>
         <a href="#">Més votats</a>
         <ul class="menu">

--- a/source/partials/_order_by_processes.html.erb
+++ b/source/partials/_order_by_processes.html.erb
@@ -8,7 +8,7 @@
   </h2>
   <div class="order-by__dropdown order-by__dropdown--right">
     <span class="order-by__text">Ordenar per:</span>
-    <ul class="dropdown menu" data-dropdown-menu>
+    <ul class="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
       <li>
         <a href="#">Más recientes</a>
         <ul class="menu">

--- a/source/partials/_topbar.html.erb
+++ b/source/partials/_topbar.html.erb
@@ -12,7 +12,7 @@
       </a>
     </div>
     <div class="topbar__dropmenu language-choose">
-      <ul class="dropdown menu" data-dropdown-menu>
+      <ul class="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
         <li class="is-dropdown-submenu-parent">
           <a href="#">Català</a>
           <ul class="menu is-dropdown-submenu">


### PR DESCRIPTION
#### :tophat: Scope of work
This is a Foundation bug that will be fixed in the next version. In touch interactions, dropdown menu links are not being followed. Temporary fix until having a new version of Foundation: adding an attribute to the dropdown menu.

See also: http://stackoverflow.com/questions/40744762/foundation-top-bar-menu-vertical-dropdown-not-clickable-on-tablets/40745013#40745013

#### :pushpin: Related Issues
- Fixes #93 


#### :ghost: GIF (optional)
![](http://i.giphy.com/pP3yXxuuPeHug.gif)
