### PR TITLE
Forms validation with Foundation Abide

### DIFF
--- a/source/form-validation.html.erb
+++ b/source/form-validation.html.erb
@@ -1,0 +1,128 @@
+---
+title: Registro -- Decidim Barcelona
+---
+
+<%= partial 'partials/template_top' %>
+
+<main class="wrapper">
+  <div class="row collapse">
+    <div class="row collapse">
+      <div class="columns large-8 large-centered text-center">
+        <h1 class="heading1 page-title">Validación de formularios con Abide</h1>
+      </div>
+    </div>
+    <div class="row">
+      <div class="columns medium-7 large-5 medium-centered">
+        <div class="card">
+          <div class="card__content">
+            <form class="register-form" data-abide novalidate>
+              <div data-abide-error class="alert callout" style="display: none;">
+                <p><i class="fi-alert"></i> Hay errores en el formulario. Por favor, revísalo.</p>
+              </div>
+              <h2 class="heading5">
+                Validación por defecto de Foundation Abide (mensaje de error a
+                 continuación del input)
+              </h2>
+              <div class="section">
+                <label>Selecciona una opción
+                  <select required>
+                    <option value=""></option>
+                    <option value="1">Opción 1</option>
+                    <option value="2">Opción 2</option>
+                    <option value="3">Opción 3</option>
+                  </select>
+                  <span class="form-error">
+                    Por favor, selecciona una opción.
+                  </span>
+                </label>
+              </div>
+              <h2 class="heading5">
+                Validación con mensaje de error no contiguo (custom)
+              </h2>
+              <div class="section">
+                <label>Número de documento
+                  <input type="text" required data-custom-error="doc-error">
+                </label>
+                <span class="custom-error" id="doc-error">
+                  Falta el número de documento.
+                </span>
+              </div>
+
+              <h2 class="heading5">
+                Validación con mensaje de error común (custom)
+              </h2>
+              <div class="section">
+                <fieldset class="row">
+                  <legend class="columns">Data de naixement</legend>
+                  <div class="columns small-4">
+                    <label><span class="show-for-sr">Dia</span>
+                      <select required data-custom-error="date-error">
+                        <option value="">Dia</option>
+                        <option value="1">1</option>
+                        <option value="2">2</option>
+                        <option value="3">3</option>
+                      </select>
+                    </label>
+                  </div>
+                  <div class="columns small-4">
+                    <label><span class="show-for-sr">Mes</span>
+                      <select required data-custom-error="date-error">
+                        <option value="">Mes</option>
+                        <option value="1">Gener</option>
+                        <option value="2">Febrer</option>
+                        <option value="3">Març</option>
+                      </select>
+                    </label>
+                  </div>
+                  <div class="columns small-4">
+                    <label><span class="show-for-sr">Any</span>
+                      <select required data-custom-error="date-error">
+                        <option value="">Any</option>
+                        <option value="1">1910</option>
+                        <option value="2">1901</option>
+                        <option value="3">1902</option>
+                      </select>
+                    </label>
+                  </div>
+                </fieldset>
+                <div class="custom-error" id="date-error">
+                  Por favor, introduce la fecha correctamente.
+                </div>
+              </div>
+              <h2 class="heading5">
+                Validación con mensaje de error (custom) cuando ya hay un texto de ayuda
+              </h2>
+              <div class="section">
+                <label>Codi postal
+                  <input type="text" required data-custom-error="cp-error">
+                </label>
+                <div class="custom-error" id="cp-error">
+                  Por favor, introduce un código postal.
+                </div>
+                <p class="help-text">Per verificar les teves dades has d'estar
+                  empadronat al municipi de Barcelona</p>
+              </div>
+              <h2 class="heading5">
+                Validación con mensaje custom en checkbox + label inline
+              </h2>
+              <div class="section">
+                <label>
+                  <input type="checkbox" required data-custom-error="terms-error">
+                  Estic d'acord amb <a href="/static" target="_blank">els termes
+                  d'accés al padró</a>.
+                </label>
+                <div class="custom-error custom-error--simple" id="terms-error">
+                  Es necesario aceptar los términos y condiciones para poder registrarse.
+                </div>
+              </div>
+              <button type="submit" class="button expanded">
+                Enviar formulario</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<%= partial 'partials/template_bottom' %>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -92,6 +92,7 @@ activesection: home
         <h2 class="section-heading">Librería de patrones</h2>
         <ul>
           <li><a href="/pattern-library">Librería de patrones de la interfaz</a></li>
+          <li><a href="/form-validation">Validación en formularios</a></li>
           <li><a href="/user-stories">User stories</a></li>
           <li><a href="/style-manual">Manual de estilo</a></li>
         </ul>

--- a/source/javascripts/body.js
+++ b/source/javascripts/body.js
@@ -3,6 +3,8 @@
 
 //= require foundation_requires
 
+//= require form_validation_custom_errors
+
 //= require appendAround.js
 //= require svg4everybody.min.js
 //= require progressFixed.js
@@ -14,4 +16,5 @@ $(".js-append").appendAround();
 $(function(){
   svg4everybody();
   progressFixed();
+  formValidationCustomErrors();
 });

--- a/source/javascripts/form_validation_custom_errors.js
+++ b/source/javascripts/form_validation_custom_errors.js
@@ -1,0 +1,25 @@
+function formValidationCustomErrors(){
+  var formTrigger = document.querySelectorAll("[data-abide]");
+
+  function formDisplayCustomErrors(){
+    var customErrors = document.querySelectorAll("[data-custom-error].is-invalid-input"),
+    displayedCustomErrors = document.querySelectorAll(".is-custom-error-visible");
+
+    //Remove error classes before validations
+    for (var i = "0"; i < displayedCustomErrors.length; i++){
+      displayedCustomErrors[i].classList.remove("is-custom-error-visible");
+    }
+
+    //Show custom errors
+    for (var i = "0"; i < customErrors.length; i++){
+      var targetError = customErrors[i].getAttribute("data-custom-error");
+      document.querySelector("#" + targetError).classList.add("is-custom-error-visible");
+    }
+  }
+
+  //Form listener for submit and changes
+  for (var i = "0"; i < formTrigger.length; i++){
+    formTrigger[i].addEventListener("submit", formDisplayCustomErrors);
+    formTrigger[i].addEventListener("change", formDisplayCustomErrors);
+  }
+}

--- a/source/javascripts/foundation_requires.js
+++ b/source/javascripts/foundation_requires.js
@@ -15,3 +15,4 @@
 // = require foundation-sites/dist/js/plugins/foundation.util.nest.js
 // = require foundation-sites/dist/js/plugins/foundation.util.touch.js
 // = require foundation-sites/dist/js/plugins/foundation.util.triggers.js
+// = require foundation-sites/dist/js/plugins/foundation.abide.js

--- a/source/stylesheets/modules/_forms.scss
+++ b/source/stylesheets/modules/_forms.scss
@@ -1,4 +1,6 @@
-/* Froms foundation overwrites*/
+$input-margin: 1.5rem;
+
+// Froms foundation overwrites
 
 .input-group-button button{
   height: 2.5rem;
@@ -14,7 +16,7 @@ label > [type='radio']{
   margin-bottom: 0; //fixes some problems with line-height in double-line labels
 }
 
-/* Switch additional styles */
+// Switch additional styles
 
 .switch-with-label{
   > label{
@@ -27,4 +29,17 @@ label > [type='radio']{
     margin-right: 1rem;
     flex-shrink: 0;
   }
+}
+
+//Custom errors
+.custom-error{
+  @extend .form-error;
+}
+
+.custom-error--simple{
+  margin-top: 0;
+}
+
+.is-custom-error-visible{
+  display: block;
 }


### PR DESCRIPTION
#### :tophat: Scope of work
Forms validation with Foundation Abide and a JS extension for custom error messages.

Usage:
- `data-abide novalidate` in `<form>`
- `required`in input field
- `<span class="form-error">…</span>` next to the input/select for default Abide validation.
- `<span class="custom-error" id="XXX">…</span>` and `data-custom-error="XXX"`for custom message validation.

#### :pushpin: Related Issues
- Fixes #129 

#### :ghost: GIF (optional)
![WHY GIPHY DOESN'T WORK ANYMORE SO SAD](http://i.giphy.com/hsJErtIsy46g8.gif)
