### PR TITLE
Datepicker for date inputs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "foundation-sites": "~6.3.0",
     "what-input": "~4.0.4",
-    "modernizr": "~2.8.3"
+    "modernizr": "~2.8.3",
+    "foundation-datepicker": "~1.5.6"
   }
 }

--- a/source/form-datepicker.html.erb
+++ b/source/form-datepicker.html.erb
@@ -1,0 +1,44 @@
+---
+title: Registro -- Decidim Barcelona
+---
+
+<%= partial 'partials/template_top' %>
+
+<main class="wrapper">
+  <div class="row collapse">
+    <div class="row collapse">
+      <div class="columns large-8 large-centered text-center page-title">
+        <h1 class="heading1">Formulario con Foundation Datepicker</h1>
+      </div>
+    </div>
+    <div class="row">
+      <div class="columns large-6 medium-10 medium-centered">
+        <div class="card">
+          <div class="card__content">
+            <form class="register-form">
+              <p>
+                Lanzado con el atributo <code>data-datepicker</code> en un <code>&lt;input type="text"&gt;</code>.
+              </p>
+              <p>
+                Fecha inicial con el atributo <code>data-startdate</code>
+                 (dd-mm-yyyy), puede estar en blanco.
+              </p>
+              <p>
+                Idioma recogido con el atributo <code>lang</code> de la etiqueta
+                 <code>&lt;html&gt;</code> o inglés si falla.
+              </p>
+              <div>
+                <label>Fecha
+                  <input type="text" data-datepicker data-startdate="" required name="process-date" placeholder="dd/mm/aaaa" id="process-date">
+                </label>
+              </div>
+              <button type="submit" class="button expanded">Enviar</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<%= partial 'partials/template_bottom' %>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -92,6 +92,7 @@ activesection: home
         <h2 class="section-heading">Librería de patrones</h2>
         <ul>
           <li><a href="/pattern-library">Librería de patrones de la interfaz</a></li>
+          <li><a href="/form-datepicker">Formulario con calendario/datepicker</a></li>
           <li><a href="/user-stories">User stories</a></li>
           <li><a href="/style-manual">Manual de estilo</a></li>
         </ul>

--- a/source/javascripts/body.js
+++ b/source/javascripts/body.js
@@ -2,7 +2,11 @@
 //= require what-input/dist/what-input.min
 
 //= require foundation_requires
+//= require foundation-datepicker/js/foundation-datepicker
+//= require foundation-datepicker/js/locales/foundation-datepicker.es.js
+//= require foundation-datepicker/js/locales/foundation-datepicker.ca.js
 
+//= require form_datepicker
 //= require appendAround.js
 //= require svg4everybody.min.js
 //= require progressFixed.js
@@ -14,4 +18,5 @@ $(".js-append").appendAround();
 $(function(){
   svg4everybody();
   progressFixed();
+  formDatePicker();
 });

--- a/source/javascripts/form_datepicker.js
+++ b/source/javascripts/form_datepicker.js
@@ -1,0 +1,16 @@
+function formDatePicker(){
+  $('[data-datepicker]').each(
+    function(){
+      var customStartDate = $(this).attr('data-startdate') || '',
+      selectedLang = $("html").attr('lang') || '';
+      $(this).fdatepicker({
+    		initialDate: customStartDate,
+    		format: 'dd-mm-yyyy',
+        language: selectedLang,
+    		disableDblClickSelection: true,
+    		leftArrow:'<<',
+    		rightArrow:'>>'
+    	});
+    }
+  );
+}

--- a/source/stylesheets/_decidim.scss
+++ b/source/stylesheets/_decidim.scss
@@ -6,4 +6,5 @@
 @include foundation-everything;
 
 @import "modules/modules";
+@import "plugins/plugins";
 @import "layouts/*";

--- a/source/stylesheets/plugins/_foundation-datepicker.scss
+++ b/source/stylesheets/plugins/_foundation-datepicker.scss
@@ -7,6 +7,7 @@ $calendar-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 $calendar-color-old: $medium-gray;
 $calendar-color-disabled: $light-gray;
 $calendar-radius: $global-radius;
+$calendar-font-size: $global-font-size * .9;
 
 .datepicker {
   display: none;
@@ -30,7 +31,7 @@ $calendar-radius: $global-radius;
   border-radius: $calendar-radius;
   box-shadow: $calendar-shadow;
   background-clip: padding-box;
-  font-size: 13px;
+  font-size: $calendar-font-size;
   line-height: 18px;
 }
 
@@ -39,7 +40,7 @@ $calendar-radius: $global-radius;
 }
 
 .datepicker.dropdown-menu td {
-  padding: 4px 5px;
+  padding: 6px 9px;
 }
 
 .datepicker table {
@@ -63,7 +64,7 @@ $calendar-radius: $global-radius;
   width: 20px;
   height: 20px;
   border: 0;
-  font-size: 12px;
+  font-size: $calendar-font-size;
   padding: 4px 8px;
   background: $calendar-bg-color;
   cursor: pointer;
@@ -110,7 +111,7 @@ $calendar-radius: $global-radius;
   width: 20px;
   height: 20px;
   border: 0;
-  font-size: 12px;
+  font-size: $calendar-font-size;
   padding: 4px 8px;
   background: $calendar-bg-color;
   cursor: pointer;

--- a/source/stylesheets/plugins/_foundation-datepicker.scss
+++ b/source/stylesheets/plugins/_foundation-datepicker.scss
@@ -1,0 +1,223 @@
+$calendar-bg-color: $white;
+$calendar-border: 1px solid rgba(0, 0, 0, 0.1);
+$calendar-border-color: rgba(0, 0, 0, 0.1);
+$calendar-active-color: $primary-color;
+$calendar-bg-hover: $light-gray;
+$calendar-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+$calendar-color-old: $medium-gray;
+$calendar-color-disabled: $light-gray;
+$calendar-radius: $global-radius;
+
+.datepicker {
+  display: none;
+  position: absolute;
+  padding: 4px;
+  margin-top: 1px;
+  direction: ltr;
+}
+
+.datepicker.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  float: left;
+  display: none;
+  min-width: 160px;
+  list-style: none;
+  background-color: $calendar-bg-color;
+  border: $calendar-border;
+  border-radius: $calendar-radius;
+  box-shadow: $calendar-shadow;
+  background-clip: padding-box;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.datepicker.dropdown-menu th {
+  padding: 4px 5px;
+}
+
+.datepicker.dropdown-menu td {
+  padding: 4px 5px;
+}
+
+.datepicker table {
+  border: 0;
+  margin: 0;
+  width: auto;
+}
+
+.datepicker table tr td span {
+  display: block;
+  width: 23%;
+  height: 54px;
+  line-height: 54px;
+  float: left;
+  margin: 1%;
+  cursor: pointer;
+}
+
+.datepicker td {
+  text-align: center;
+  width: 20px;
+  height: 20px;
+  border: 0;
+  font-size: 12px;
+  padding: 4px 8px;
+  background: $calendar-bg-color;
+  cursor: pointer;
+}
+
+.datepicker td.active.day,
+.datepicker td.active.year {
+  background: $calendar-active-color;
+}
+
+.datepicker .day:hover,
+.datepicker .date-switch:hover,
+.datepicker .prev:hover,
+.datepicker .next:hover,
+.datepicker .month:hover,
+.datepicker .year:hover{
+  background-color: $calendar-bg-hover;
+  &.active{
+    background: $calendar-active-color;
+  }
+}
+
+
+.datepicker td.new,
+.datepicker td.old {
+  color: $calendar-color-old;
+}
+
+.datepicker td span.active {
+  background: $calendar-active-color;
+}
+
+.datepicker td.day.disabled {
+  color: $calendar-color-disabled;
+}
+
+.datepicker td span.month.disabled,
+.datepicker td span.year.disabled {
+  color: $calendar-color-disabled;
+}
+
+.datepicker th {
+  text-align: center;
+  width: 20px;
+  height: 20px;
+  border: 0;
+  font-size: 12px;
+  padding: 4px 8px;
+  background: $calendar-bg-color;
+  cursor: pointer;
+}
+
+.datepicker th.active.day,
+.datepicker th.active.year {
+  background: $calendar-active-color;
+}
+
+.datepicker th.date-switch {
+  width: 145px;
+}
+
+.datepicker th span.active {
+  background: $calendar-active-color;
+}
+
+.datepicker .cw {
+  font-size: 10px;
+  width: 12px;
+  padding: 0 2px 0 5px;
+  vertical-align: middle;
+}
+
+.datepicker.days div.datepicker-days {
+  display: block;
+}
+
+.datepicker.months div.datepicker-months {
+  display: block;
+}
+
+.datepicker.years div.datepicker-years {
+  display: block;
+}
+
+.datepicker thead tr:first-child th {
+  cursor: pointer;
+}
+
+.datepicker thead tr:first-child th.cw {
+  cursor: default;
+  background-color: transparent;
+}
+
+.datepicker tfoot tr:first-child th {
+  cursor: pointer;
+}
+
+.datepicker-inline {
+  width: 220px;
+}
+
+.datepicker-rtl {
+  direction: rtl;
+}
+
+.datepicker-rtl table tr td span {
+  float: right;
+}
+
+.datepicker-dropdown {
+  top: 0;
+  left: 0;
+}
+
+.datepicker-dropdown:before {
+  content: '';
+  display: inline-block;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #ccc;
+  border-bottom-color: $calendar-border-color;
+  position: absolute;
+  top: -7px;
+  left: 6px;
+}
+
+.datepicker-dropdown:after {
+  content: '';
+  display: inline-block;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid $calendar-bg-color;
+  position: absolute;
+  top: -6px;
+  left: 7px;
+}
+
+.datepicker > div,
+.datepicker-dropdown::after,
+.datepicker-dropdown::before {
+  display: none;
+}
+
+.datepicker-close {
+  position: absolute;
+  top: -30px;
+  right: 0;
+  width: 15px;
+  height: 30px;
+  padding: 0;
+  display: none;
+}
+
+.table-striped .datepicker table tr td,
+.table-striped .datepicker table tr th {
+  background-color: transparent;
+}

--- a/source/stylesheets/plugins/_plugins.scss
+++ b/source/stylesheets/plugins/_plugins.scss
@@ -1,0 +1,1 @@
+@import "foundation-datepicker";


### PR DESCRIPTION
#### :tophat: Scope of work
Foundation datepicker, behaviour and styles for date inputs. Use `<input type="text">` instead.

Related to https://github.com/AjuntamentdeBarcelona/decidim-design-admin/pull/15